### PR TITLE
Add a global exception handling service

### DIFF
--- a/TeacherPlanner/App.xaml.cs
+++ b/TeacherPlanner/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Windows;
+using TeacherPlanner.Services;
 
 namespace TeacherPlanner
 {
@@ -7,5 +8,11 @@ namespace TeacherPlanner
     /// </summary>
     public partial class App : Application
     {
+        private readonly ExceptionHandlerService _exceptionHandlerService;
+        public App()
+        {
+            _exceptionHandlerService = new ExceptionHandlerService();
+            _exceptionHandlerService.Attach();
+        }
     }
 }

--- a/TeacherPlanner/Helpers/ControlExtensions.cs
+++ b/TeacherPlanner/Helpers/ControlExtensions.cs
@@ -12,6 +12,7 @@ namespace TeacherPlanner.Helpers
         public static string GetHeaderOfPreviouslySelectedTab(SelectionChangedEventArgs e)
         {
             TabItem[] tabItems = new TabItem[e.RemovedItems.Count];
+            // TODO: There's a crash on this line below
             e.RemovedItems.CopyTo(tabItems, 0);
             if (tabItems.Any())
             {

--- a/TeacherPlanner/Services/ExceptionHandlerService.cs
+++ b/TeacherPlanner/Services/ExceptionHandlerService.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Windows;
+
+namespace TeacherPlanner.Services
+{
+    public class ExceptionHandlerService
+    {
+        public void Attach()
+        {
+            Application.Current.DispatcherUnhandledException += OnDispatcherUnhandledException;
+        }
+      
+        private void OnDispatcherUnhandledException(object sender,
+            System.Windows.Threading.DispatcherUnhandledExceptionEventArgs e)
+        {
+            try
+            {
+                var errorMessage = $"An unhandled exception occurred and the app must shut down.\nPlease see the logs at {GetLogFilePath()}";
+                MessageBox.Show(errorMessage, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                WriteExceptionToLogFile(e.Exception);
+                e.Handled = true;
+            }
+            // If something goes wrong during the exception handling, we want to catch it
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+            }
+            finally
+            {
+                Application.Current.Shutdown();
+            }
+        }
+
+        private static void WriteExceptionToLogFile(Exception exception)
+        {
+            var logPath = GetLogFilePath();
+            var fileName = DateTime.Now.ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture)+".txt";
+            var filePath = Path.Combine(logPath, fileName);
+         
+            if (!Directory.Exists(logPath))
+                Directory.CreateDirectory(logPath);
+         
+            File.WriteAllText(filePath, exception.ToString());
+        }
+
+        private static string GetLogFilePath()
+        {
+            // TODO: Change this to where you want the logs to go.
+            var appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(appDataPath, "TeacherPlanner", "Logs");
+        }
+    }
+}


### PR DESCRIPTION
- Added a global exception handling service that should catch and write a log for any exceptions that are thrown.
- Also identified a crash that's happening on changing tabs, and added a TODO.
- One caveat I noticed in a (very brief) testing of this service, is that if you crash in the login window, it logs out 3 crashes (cascaded down from how the login window shuts down the app)